### PR TITLE
Pin Mysql Docker version to 5.

### DIFF
--- a/docker-compose.yml.dist
+++ b/docker-compose.yml.dist
@@ -22,7 +22,7 @@ services:
             - "traefik.frontend.rule=Host:REPLACE_WITH_YOUR_HOST"
 
     database:
-        image: mysql
+        image: mysql:5
         environment:
             MYSQL_ROOT_PASSWORD: changeme
             MYSQL_DATABASE: jeyser


### PR DESCRIPTION
Since the release of Mysql 8.0, our docker-compose is not correct anymore
Use of Mysql 8 coming in Jeyser 3.0 (only if a migration of existing installations is possible)