### PR TITLE
Update mailer base image

### DIFF
--- a/docker/mail/Dockerfile
+++ b/docker/mail/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:jessie
+FROM debian:stretch
 
 MAINTAINER Jeyser-CRM <dsi@n7consulting.fr>
 


### PR DESCRIPTION
Keep a small disk footprint by using same base image as php:7.1-apache