### PR TITLE
Petites retouches

### DIFF
--- a/src/Mgate/StatBundle/Resources/views/Indicateurs/index.html.twig
+++ b/src/Mgate/StatBundle/Resources/views/Indicateurs/index.html.twig
@@ -110,6 +110,35 @@
                         }
                     });
 
+            }
+        );
+
+
+        // keep tab opened through refresh
+        $(document).ready(function () {
+            // show active tab on reload
+            if (location.hash !== '') {
+                var tabSelect = $('a[href="' + location.hash + '"]');
+                var url = tabSelect.attr('data-url');
+                var div = $(location.hash);
+                if (div !== undefined) {
+                    div.load(url, function (result) {
+                        return result
+                    });
+                }
+                tabSelect.trigger('click');
+            }
+
+            // remember the hash in the URL without jumping
+            $('a[data-toggle="tab"]').on('shown.bs.tab', function (e) {
+                var url = $(this).attr("data-url");
+                var href = this.hash;
+                if (history.pushState) {
+                    history.pushState(null, null, '#' + $(e.target).attr('href').substr(1));
+                } else {
+                    location.hash = '#' + $(e.target).attr('href').substr(1);
+                }
             });
+        });
     </script>
 {% endblock %}

--- a/src/Mgate/UserBundle/Resources/views/Default/lister.html.twig
+++ b/src/Mgate/UserBundle/Resources/views/Default/lister.html.twig
@@ -20,8 +20,7 @@
 {% endblock %}
 
 {% block content_bundle %}
-
-    <table class="table table-bordered table-striped dataTable dt-responsive" id="listeUser" role="grid">
+    <table class="table table-bordered table-striped dataTable dt-responsive text-left" id="listeUser" role="grid" width="100%">
         <thead>
         <tr>
             <th>Nom d'utilisateur</th>


### PR DESCRIPTION
- Table des utilisateurs désormait responsive `/user/lister`
- Les onglets de la page indicateur restent ouvert à l'actualisation de la page (comme pour les pages des études) `/admin/indicateurs`