### PR TITLE
Keep side menu open

### DIFF
--- a/src/Controller/Privacy/PrivacyController.php
+++ b/src/Controller/Privacy/PrivacyController.php
@@ -136,7 +136,7 @@ class PrivacyController extends AbstractController
 
     private function export(Personne $personne, SerializerInterface $serializer)
     {
-        $data = $serializer->serialize($personne, null, ['groups' => ['gdpr']]);
+        $data = $serializer->serialize($personne, 'json', ['groups' => ['gdpr']]);
 
         $response = new JsonResponse($data);
         $response->headers->set('Cache-Control', 'private');

--- a/src/Controller/Publish/DocumentController.php
+++ b/src/Controller/Publish/DocumentController.php
@@ -101,7 +101,7 @@ class DocumentController extends AbstractController
         if (!$response = $this->upload($request, false, ['etude' => $etude], $documentManager, $kernel)) {
             $this->addFlash('success', 'Document mis en ligne');
 
-            return $this->redirectToRoute('project_etude_voir', ['nom' => $etude->getNom()]);
+            return $this->redirectToRoute('project_etude_voir', ['nom' => $etude->getNom(), '_fragment' => 'tab5']);
         }
 
         return $response;
@@ -125,7 +125,7 @@ class DocumentController extends AbstractController
         if (!$response = $this->upload($request, false, $options, $documentManager, $kernel)) {
             $this->addFlash('success', 'Document mis en ligne');
 
-            return $this->redirectToRoute('personne_membre_voir', ['id' => $membre->getId()]);
+            return $this->redirectToRoute('personne_membre_voir', ['id' => $membre->getId(), '_fragment' => 'tab2']);
         }
 
         return $response;

--- a/templates/Dashboard/Navbar/staff.html.twig
+++ b/templates/Dashboard/Navbar/staff.html.twig
@@ -22,7 +22,6 @@
 
     <!-- GESTION ASSOCIATIVE -->
     {% if is_granted('ROLE_SUIVEUR') %}
-
         <li>
             <a href="#">
                 <i class="icon-mini fa fa-book"></i>
@@ -220,7 +219,7 @@
 
     <!-- PILOTAGE DE LA J.E. -->
     {% if is_granted('ROLE_CA') %}
-        <li class="">
+        <li>
             <a href="#">
                 <i class="icon-mini fa fa-paper-plane"></i>
                 <span class="nav-label">{{ 'dashboard.pilotage_je'| trans }}</span>

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -148,6 +148,48 @@ along with Incipio as the file LICENSE.  If not, see <http://www.gnu.org/license
         });
         $(".loading").hide();
     </script>
+
+    <script>
+        $(function () {
+            function stripTrailingSlash(str) {
+                if (str.substr(-1) === '/') {
+                    return str.substr(0, str.length - 1);
+                }
+                return str;
+            }
+
+            function addActiveClass(element){
+                if(element.is("li")){
+                    element.addClass('active');
+                    addActiveClass(element.parent().parent());
+                }
+            }
+
+            let url = window.location.href;
+            let activePage = stripTrailingSlash(url);
+            let linkFound = false;
+            $('.sidebar-menu li a').each(function () {
+                let currentLink = stripTrailingSlash($(this).attr('href'));
+                if (activePage.endsWith(currentLink)) {
+                        addActiveClass($(this).parent());
+                        linkFound = true;
+                }
+            });
+            if(!linkFound){ // Less sensitive match
+                $('.sidebar-menu li a').each(function () {
+                    if(!linkFound){
+                        let currentLink = stripTrailingSlash($(this).attr('href'));
+                        if (activePage.indexOf(currentLink) !== -1) {
+                            addActiveClass($(this).parent());
+                            linkFound = true;
+                        }
+                    }
+                });
+            }
+        });
+    </script>
+
+    {% if param('gaTracking') is not null %}
     <!-- GOOGLE ANALYTICS -->
     <script>
         (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
@@ -159,7 +201,7 @@ along with Incipio as the file LICENSE.  If not, see <http://www.gnu.org/license
         ga('send', 'pageview');
 
     </script>
-
+    {% endif %}
 {% endblock %}
 
 </body>


### PR DESCRIPTION
Cette PR permet au menu de navigation latéral de rester ouvert sur la rubrique dans laquelle l'utilisateur se trouve afin de faciliter la navigation.


Elle corrige aussi un bug empêchant l'export des données d'un utililisateur. 