### PR TITLE
Move traefik SSL key type to EC256 for better performances

### DIFF
--- a/docker-compose.yml.dist
+++ b/docker-compose.yml.dist
@@ -44,7 +44,7 @@ services:
             --defaultEntryPoints='http,https' --entryPoints='Name:http Address::80 Redirect.EntryPoint:https'
             --entryPoints='Name:https Address::443 TLS' --acme.entryPoint=https
             --acme.email='REPLACE_WITH_YOUR_EMAIL' --acme.storage=/acme.json --acme.onDemand=true
-            --acme.httpChallenge.entryPoint=http
+            --acme.httpChallenge.entryPoint=http --acme.keytype=EC256
         ports:
             - "80:80"
             - "8080:8080"


### PR DESCRIPTION
Related to https://github.com/containous/traefik/issues/2673

On another project, moving to EC256 for SSL key type reduced stress test time from 36s for 10k requests to 16s.