### PR TITLE
Various fixes - "Devis" Generation is now available

### DIFF
--- a/src/Command/CreateDemoDataCommand.php
+++ b/src/Command/CreateDemoDataCommand.php
@@ -414,7 +414,7 @@ class CreateDemoDataCommand extends Command
                     $pv->setSignataire1($this->president->getPersonne());
                     $pv->setSignataire2(null !== $emp ? $emp->getPersonne() : null);
                     $pv->setType('pvr');
-                    $this->validateObject('New PVR', $pv);
+                    $this->validateObject('New PVRF', $pv);
                     $this->em->persist($pv);
                 }
 

--- a/src/Controller/Project/ProcesVerbalController.php
+++ b/src/Controller/Project/ProcesVerbalController.php
@@ -128,7 +128,7 @@ class ProcesVerbalController extends AbstractController
      * @Security("has_role('ROLE_SUIVEUR')")
      * @Route(name="project_procesverbal_rediger", path="/suivi/procesverbal/rediger/{id}/{type}", methods={"GET","HEAD","POST"})
      *
-     * @param string $type PVR or PVRI
+     * @param string $type PVRF or PVRI
      *
      * @return RedirectResponse|Response
      */
@@ -142,7 +142,7 @@ class ProcesVerbalController extends AbstractController
 
         if (!$procesverbal = $etude->getDoc($type)) {
             $procesverbal = new ProcesVerbal();
-            if ('PVR' == strtoupper($type)) {
+            if (\App\Controller\Publish\TraitementController::DOCTYPE_PROCES_VERBAL_FINAL == strtoupper($type)) {
                 $etude->setPvr($procesverbal);
             }
             $procesverbal->setType($type);

--- a/src/Controller/Publish/TraitementController.php
+++ b/src/Controller/Publish/TraitementController.php
@@ -53,7 +53,7 @@ class TraitementController extends AbstractController
 
     const DOCTYPE_FACTURE_SOLDE = 'FS';
 
-    const DOCTYPE_PROCES_VERBAL_INTERMEDIAIRE = 'PVI';
+    const DOCTYPE_PROCES_VERBAL_INTERMEDIAIRE = 'PVRI';
 
     const DOCTYPE_PROCES_VERBAL_FINAL = 'PVR';
 

--- a/src/Controller/Publish/TraitementController.php
+++ b/src/Controller/Publish/TraitementController.php
@@ -55,7 +55,7 @@ class TraitementController extends AbstractController
 
     const DOCTYPE_PROCES_VERBAL_INTERMEDIAIRE = 'PVRI';
 
-    const DOCTYPE_PROCES_VERBAL_FINAL = 'PVR';
+    const DOCTYPE_PROCES_VERBAL_FINAL = 'PVRF';
 
     const DOCTYPE_RECAPITULATIF_MISSION = 'RM';
 

--- a/src/DataFixtures/LoadDocTypeData.php
+++ b/src/DataFixtures/LoadDocTypeData.php
@@ -39,8 +39,8 @@ class LoadDocTypeData extends Fixture
 
         //proces verbal de reception final
         $pvr = new Document();
-        $pvr->setName('PVR');
-        $pvr->setPath('PVR.docx');
+        $pvr->setName('PVRF');
+        $pvr->setPath('PVRF.docx');
         $pvr->setSize(17000);
         $manager->persist($pvr);
 

--- a/src/Entity/Project/Etude.php
+++ b/src/Entity/Project/Etude.php
@@ -557,7 +557,7 @@ class Etude
                 throw new \Exception('Missing implementation of getFis() on Etude entity');
             case 'FS':
                 return $this->getFs();
-            case 'PVR':
+            case \App\Controller\Publish\TraitementController::DOCTYPE_PROCES_VERBAL_FINAL:
                 return $this->getPvr();
             case \App\Controller\Publish\TraitementController::DOCTYPE_PROCES_VERBAL_INTERMEDIAIRE:
                 return $this->getPvis($key);

--- a/src/Entity/Project/Etude.php
+++ b/src/Entity/Project/Etude.php
@@ -559,7 +559,7 @@ class Etude
                 return $this->getFs();
             case 'PVR':
                 return $this->getPvr();
-            case 'PVI':
+            case \App\Controller\Publish\TraitementController::DOCTYPE_PROCES_VERBAL_INTERMEDIAIRE:
                 return $this->getPvis($key);
             case 'AV':
                 return $this->getAvs()->get($key);

--- a/src/Entity/Project/ProcesVerbal.php
+++ b/src/Entity/Project/ProcesVerbal.php
@@ -65,7 +65,7 @@ class ProcesVerbal extends DocType
     public function getReference()
     {
         return $this->etude->getReference() . '/' . (null !== $this->etude->getCc()->getDateSignature() ?
-                $this->etude->getCc()->getDateSignature()->format('Y') : '') . '/PVR/' . $this->getVersion();
+                $this->etude->getCc()->getDateSignature()->format('Y') : '') . '/PVRF/' . $this->getVersion();
     }
 
     /**
@@ -174,6 +174,6 @@ class ProcesVerbal extends DocType
 
     public function __toString()
     {
-        return $this->etude->getReference() . '/PVR/';
+        return $this->etude->getReference() . '/PVRF/';
     }
 }

--- a/src/Form/Project/SuiviEtudeType.php
+++ b/src/Form/Project/SuiviEtudeType.php
@@ -85,7 +85,7 @@ class SuiviEtudeType extends AbstractType
                 'by_reference' => false, //indispensable cf doc
             ]
         );
-        $builder->add('pvr', DocTypeSuiviType::class, ['label' => 'PVR', 'data_class' => ProcesVerbal::class]);
+        $builder->add('pvr', DocTypeSuiviType::class, ['label' => 'PVRF', 'data_class' => ProcesVerbal::class]);
     }
 
     public function getBlockPrefix()

--- a/src/Form/Treso/FactureType.php
+++ b/src/Form/Treso/FactureType.php
@@ -12,6 +12,7 @@
 namespace App\Form\Treso;
 
 use App\Entity\Personne\Prospect;
+use App\Entity\Project\Etude;
 use App\Entity\Treso\Facture;
 use Genemu\Bundle\FormBundle\Form\JQuery\Type\DateType;
 use Genemu\Bundle\FormBundle\Form\JQuery\Type\Select2EntityType;
@@ -43,6 +44,11 @@ class FactureType extends AbstractType
                  ],
                 ]
             )
+            ->add('etude', Select2EntityType::class, [
+                'label' => 'Etude',
+                'class' => Etude::class,
+                'choice_label' => 'nom',
+                ])
             ->add('details', CollectionType::class, [
                 'entry_type' => FactureDetailType::class,
                 'allow_add' => true,

--- a/src/Service/Project/EtudeManager.php
+++ b/src/Service/Project/EtudeManager.php
@@ -106,11 +106,11 @@ class EtudeManager
             return $name . '-' . $type . ($key + 1);
         } elseif ('FS' == $type) {
             return $name . '-' . $type;
-        } elseif ('PVI' == $type) {
+        } elseif (\App\Controller\Publish\TraitementController::DOCTYPE_PROCES_VERBAL_INTERMEDIAIRE == $type) {
             if ($key >= 0 && $etude->getPvis($key)) {
                 return $name . '-' . $type . ($key + 1) . '-' . $etude->getPvis($key)->getVersion();
             } else {
-                return $name . '-' . $type . ($key + 1) . '- ERROR GETTING PVI';
+                return $name . '-' . $type . ($key + 1) . '- ERROR GETTING PVRI';
             }
         } elseif ('PVR' == $type) {
             if ($etude->getPvr()) {

--- a/src/Service/Project/EtudeManager.php
+++ b/src/Service/Project/EtudeManager.php
@@ -112,7 +112,7 @@ class EtudeManager
             } else {
                 return $name . '-' . $type . ($key + 1) . '- ERROR GETTING PVRI';
             }
-        } elseif ('PVR' == $type) {
+        } elseif (\App\Controller\Publish\TraitementController::DOCTYPE_PROCES_VERBAL_FINAL == $type) {
             if ($etude->getPvr()) {
                 return $name . '-' . $type . '-' . $etude->getPvr()->getVersion();
             } else {

--- a/src/Service/Project/EtudeManager.php
+++ b/src/Service/Project/EtudeManager.php
@@ -11,7 +11,7 @@
 
 namespace App\Service\Project;
 
-use App\Entity\Project\Cc;
+use App\Entity\Project\Ce;
 use App\Entity\Project\Etude;
 use Doctrine\Common\Persistence\ObjectManager;
 use Webmozart\KeyValueStore\Api\KeyValueStore;
@@ -228,14 +228,14 @@ class EtudeManager
     }
 
     /**
-     * Get le maximum des mandats par rapport à la date de Signature de signature des CC.
+     * Get le maximum des mandats par rapport à la date de Signature de signature des CE.
      */
-    public function getMaxMandatCc()
+    public function getmaxMandatCe()
     {
         $qb = $this->em->createQueryBuilder();
 
         $query = $qb->select('c.dateSignature')
-            ->from(Cc::class, 'c')
+            ->from(Ce::class, 'c')
             ->orderBy('c.dateSignature', 'DESC');
 
         $value = $query->getQuery()->setMaxResults(1)->getOneOrNullResult();

--- a/src/Service/Publish/SiajeEtudeImporter.php
+++ b/src/Service/Publish/SiajeEtudeImporter.php
@@ -214,7 +214,7 @@ class SiajeEtudeImporter extends CsvImporter implements FileImporterInterface
                                 $this->em->persist($cc);
                             }
 
-                            //manage PVR
+                            //manage PVRF
                             if (null !== $this->dateManager($this->readArray($data, 'Date signature PV'))) {
                                 $pv = new ProcesVerbal();
                                 $pv->setEtude($e);

--- a/src/Twig/EtudeExtension.php
+++ b/src/Twig/EtudeExtension.php
@@ -152,11 +152,11 @@ class EtudeExtension extends \Twig_Extension
             $pviAnterieur = $pvi;
         }
 
-        // PVR < fin d'étude
+        // PVRF < fin d'étude
         if ($etude->getPvr()) {
             if (null !== $etude->getDateFin(true) && $etude->getPvr()->getDateSignature() > $etude->getDateFin(true)) {
-                $error = ['titre' => 'PVR  - Date de signature : ',
-                          'message' => 'La date de signature du PVR doit être antérieure à la date de fin de l\'étude. Consulter la Convention Client ou l\'Avenant à la Convention Client pour la fin l\'étude.',
+                $error = ['titre' => 'PVRF  - Date de signature : ',
+                          'message' => 'La date de signature du PVRF doit être antérieure à la date de fin de l\'étude. Consulter la Convention Client ou l\'Avenant à la Convention Client pour la fin l\'étude.',
                 ];
                 array_push($errors, $error);
             }
@@ -197,26 +197,26 @@ class EtudeExtension extends \Twig_Extension
             }
         }
 
-        // Date de fin d'étude approche alors que le PVR n'est pas signé
+        // Date de fin d'étude approche alors que le PVRF n'est pas signé
         $now = new \DateTime('now');
         $DateAvert0 = new \DateInterval('P10D');
         if ($etude->getDateFin()) {
             if (!$etude->getPvr()) {
                 if ($now < $etude->getDateFin(true) && $etude->getDateFin(true)->sub($DateAvert0) < $now) {
                     $error = ['titre' => 'Fin de l\'étude :',
-                              'message' => 'L\'étude se termine dans moins de dix jours, pensez à faire signer le PVR ou à faire signer des avenants de délais si vous pensez que l\'étude ne se terminera pas à temps.',
+                              'message' => 'L\'étude se termine dans moins de dix jours, pensez à faire signer le PVRF ou à faire signer des avenants de délais si vous pensez que l\'étude ne se terminera pas à temps.',
                     ];
                     array_push($errors, $error);
                 } elseif ($etude->getDateFin(true) < $now) {
                     $error = ['titre' => 'Fin de l\'étude :',
-                              'message' => 'La fin de l\'étude est passée. Pensez à faire un PVR ou des avenants à la CC et au(x) RM.',
+                              'message' => 'La fin de l\'étude est passée. Pensez à faire un PVRF ou des avenants à la CC et au(x) RM.',
                     ];
                     array_push($errors, $error);
                 }
             } else {
                 if ($etude->getPvr()->getDateSignature() > $etude->getDateFin(true)) {
                     $error = ['titre' => 'Fin de l\'étude :',
-                              'message' => 'La date du PVR est située après la fin de l\'étude.',
+                              'message' => 'La date du PVRF est située après la fin de l\'étude.',
                     ];
                     array_push($errors, $error);
                 }
@@ -317,7 +317,7 @@ class EtudeExtension extends \Twig_Extension
         if ($etude->getDateFin()) {
             if ($etude->getDateFin()->sub($DateAvert1) > $now && $etude->getDateFin()->sub($DateAvert0) < $now) {
                 $warning = ['titre' => 'Fin de l\'étude :',
-                            'message' => 'l\'étude se termine dans moins de vingt jours, pensez à faire signer le PVR ou à faire signer des avenants de délais si vous pensez que l\'étude ne se terminera pas à temps.',
+                            'message' => 'l\'étude se termine dans moins de vingt jours, pensez à faire signer le PVRF ou à faire signer des avenants de délais si vous pensez que l\'étude ne se terminera pas à temps.',
                 ];
                 array_push($warnings, $warning);
             }

--- a/src/Twig/EtudeExtension.php
+++ b/src/Twig/EtudeExtension.php
@@ -228,7 +228,7 @@ class EtudeExtension extends \Twig_Extension
          *************************/
 
         // Description de l'AP suffisante
-        if (strlen($etude->getDescriptionPrestation()) < 300) {
+        if (!$etude->getCeActive() && strlen($etude->getDescriptionPrestation()) < 300) {
             $error = ['titre' => 'Description de l\'étude:',
                       'message' => 'Attention la description de l\'étude dans l\'AP fait moins de 300 caractères',
             ];

--- a/src/Twig/EtudeExtension.php
+++ b/src/Twig/EtudeExtension.php
@@ -103,15 +103,15 @@ class EtudeExtension extends \Twig_Extension
             }
         }
 
-        // CC > PVI
+        // CC > PVRI
         if ($etude->getCc()) {
             /** @var ProcesVerbal $pvi */
             foreach ($etude->getPvis() as $pvi) {
                 if (null !== $pvi->getDateSignature() && $etude->getCc()
                         ->getDateSignature() >= $pvi->getDateSignature()
                 ) {
-                    $error = ['titre' => 'PVIS, CC  - Date de signature : ',
-                              'message' => 'La date de signature de la Convention Client doit être antérieure à la date de signature des PVIS.',
+                    $error = ['titre' => 'PVRIS, CC  - Date de signature : ',
+                              'message' => 'La date de signature de la Convention Client doit être antérieure à la date de signature des PVRIS.',
                     ];
                     array_push($errors, $error);
                     break;
@@ -134,7 +134,7 @@ class EtudeExtension extends \Twig_Extension
             }
         }
 
-        //ordre PVI
+        //ordre PVRI
         /**
          * @var ProcesVerbal
          * @var ProcesVerbal $pviAnterieur
@@ -142,7 +142,7 @@ class EtudeExtension extends \Twig_Extension
         foreach ($etude->getPvis() as $pvi) {
             if (isset($pviAnterieur)) {
                 if (null !== $pvi->getDateSignature() && $pvi->getDateSignature() < $pviAnterieur->getDateSignature()) {
-                    $error = ['titre' => 'PVIS - Date de signature : ', 'message' => 'La date de signature du PVI1 doit être antérieure à celle du PVI2 et ainsi de suite.
+                    $error = ['titre' => 'PVRIS - Date de signature : ', 'message' => 'La date de signature du PVRI1 doit être antérieure à celle du PVRI2 et ainsi de suite.
            ',
                     ];
                     array_push($errors, $error);

--- a/templates/Project/Etude/TabVoir/Redaction.html.twig
+++ b/templates/Project/Etude/TabVoir/Redaction.html.twig
@@ -137,11 +137,19 @@
                                 class="fa fa-pencil"></span> {{ 'suivi.rediger'|trans({}, 'project') }}</a></li>
                 {% if etude.ce.dateSignature |default('0') %}
                     <li><a href="{{ path('publish_publiposter',
-                            { 'templateName' : constant('\\App\\Controller\\Publish\\TraitementController::DOCTYPE_CONVENTION_ETUDE'),
-                                'rootName' : constant('\\App\\Controller\\Publish\\TraitementController::ROOTNAME_ETUDE'),
-                                'rootObject_id' : etude.id}) }}">
-                            <span class="fa fa-arrow-circle-down"></span> {{ 'suivi.generer'|trans({}, 'project') }}
-                        </a></li>
+                        { 'templateName' : constant('\\App\\Controller\\Publish\\TraitementController::DOCTYPE_DEVIS'),
+                            'rootName' : constant('\\App\\Controller\\Publish\\TraitementController::ROOTNAME_ETUDE'),
+                            'rootObject_id' : etude.id}) }}">
+                        <span class="fa fa-arrow-circle-down"></span> {{ 'suivi.generer_devis'|trans({}, 'project') }}
+                    </a></li>
+                    <li><a href="{{ path('publish_publiposter',
+                        { 'templateName' : constant('\\App\\Controller\\Publish\\TraitementController::DOCTYPE_CONVENTION_ETUDE'),
+                            'rootName' : constant('\\App\\Controller\\Publish\\TraitementController::ROOTNAME_ETUDE'),
+                            'rootObject_id' : etude.id}) }}">
+                        <span class="fa fa-arrow-circle-down"></span> {{ 'suivi.generer_ce'|trans({}, 'project') }}
+                    </a></li>
+                    </tr>
+                    <li></li>
                 {% endif %}
             </ul>
         </div>

--- a/templates/Project/Etude/TabVoir/Suivi.html.twig
+++ b/templates/Project/Etude/TabVoir/Suivi.html.twig
@@ -109,7 +109,7 @@
         </tr>
         {% for av in formSuivi.avs %}
             <tr class="docTabRow">
-                <th>{{ 'suivi.pvi'|trans({}, 'project') }} n° {{ loop.index }}</th>
+                <th>{{ 'suivi.av'|trans({}, 'project') }} n° {{ loop.index }}</th>
                 <td class="state">{{ 'suivi.incomplet'|trans({}, 'project') }}</td>
                 <td>{{ form_widget(av.redige) }}</td>
                 <td>{{ form_widget(av.relu) }}</td>

--- a/templates/Treso/Facture/modifier.html.twig
+++ b/templates/Treso/Facture/modifier.html.twig
@@ -65,6 +65,13 @@
         </tr>
         <tr>
             <th colspan="2">
+                {{ form_label(form.etude) }}
+                {{ form_errors(form.etude) }}
+            </th>
+            <td colspan="2">{{ form_widget(form.etude) }}</td>
+        </tr>
+        <tr>
+            <th colspan="2">
                 {{ form_label(form.beneficiaire) }}
                 {{ form_errors(form.beneficiaire) }}
             </th>

--- a/translations/project.fr.yml
+++ b/translations/project.fr.yml
@@ -176,6 +176,8 @@ suivi:
   gantt: Gantt
   gantt_exporter: Exporter le Gantt
   generer: Generer
+  generer_ce: Générer la CE
+  generer_devis: Générer le devis
   groupe: Groupe
   groupe_ajouter: Ajouter un groupe
   groupes: groupes

--- a/translations/project.fr.yml
+++ b/translations/project.fr.yml
@@ -244,8 +244,8 @@ suivi:
   précédent: Précédent
   pvi: PVRI
   pvi_ajouter_un: Ajouter un PVRI
-  pvr: PVR
-  pvr_rediger: Rediger le PVR
+  pvr: PVRF
+  pvr_rediger: Rediger le PVRF
   raison: Raison
   realisateurs_capable_de: Les réalisateurs de cette étude devront donc être capables de
   recapitulatif: Récapitulatif

--- a/translations/project.fr.yml
+++ b/translations/project.fr.yml
@@ -53,7 +53,7 @@ suivi:
   cc: CC
   cc_affichage: Affichage d'une Convention Client
   cc_enregistrer: Enregistrer la CC
-  cc_enregistrer_pvi_passer: Enregistrer la CC et passer au PVI
+  cc_enregistrer_pvi_passer: Enregistrer la CC et passer au PVRI
   cc_liste: Liste des Convention Client
   cc_modifier: Modifier une Convention Client
   cc_modifier_la: Modifier la Convention Client
@@ -242,8 +242,8 @@ suivi:
   propales_non_abouties_texte: Propales n'ayant pas abouti à la signature d'une convention client
   prospect_ajouter: Ajouter un Prospect
   précédent: Précédent
-  pvi: PVI
-  pvi_ajouter_un: Ajouter un PVI
+  pvi: PVRI
+  pvi_ajouter_un: Ajouter un PVRI
   pvr: PVR
   pvr_rediger: Rediger le PVR
   raison: Raison

--- a/translations/project.fr.yml
+++ b/translations/project.fr.yml
@@ -45,6 +45,7 @@ suivi:
   avenant_supprimer_confirmation: Êtes-vous sûr de vouloir supprimer définitivement cet avenant ?
   avenants: Avenants
   avenants_clients: Avenants clients
+  av: AVCE
   avenants_mission: Avenants de Mission
   avortee: Avortée
   budget: Budget


### PR DESCRIPTION
## Medium fixes
- Front-end change allowing the user to link an "etude" to a "facture" when creating or modifying a facture
- Front-end change allowing the user to generate a "devis" in "suivi d'étude/Etude 1/Rédaction et génération" in the Convention d'Etude tab

## Minor fixes
- PVI becomes PVRI (as normally used)
- PVR becomes PVRF (as normally used)
Please note that these changes only affect the front-end, there are no changes in the back-end (PVRI are stilled called by pvi variables - same for PVRF with pvr variables)
- When a "avenant" was created, it was called "PVI" in the "suivi" tab. Now it is called "AVCE" (= Avenant à la Convention d'Etude) as it should be
---
Changes made by T.W. from Junior UTC